### PR TITLE
added tln-tag

### DIFF
--- a/lib/jekyll/language-plugin/tags.rb
+++ b/lib/jekyll/language-plugin/tags.rb
@@ -7,6 +7,7 @@ module Jekyll
       require_relative 'tags/language'
       require_relative 'tags/language_include'
       require_relative 'tags/language_name'
+      require_relative 'tags/language_name_native'
     end
   end
 end

--- a/lib/jekyll/language-plugin/tags/language_name_native.rb
+++ b/lib/jekyll/language-plugin/tags/language_name_native.rb
@@ -1,0 +1,31 @@
+# Frozen-string-literal: true
+# Encoding: utf-8
+
+module Jekyll
+  module LanguagePlugin
+    module Tags
+      class NativeLanguageNameTag < Liquid::Tag
+        def initialize(tag_name, markup, tokens)
+          super
+          @markup = markup
+        end
+
+        def render(context)
+          p = Liquid::Parser.new(@markup)
+          name = Liquid::Expression.parse(exp = p.expression)
+          key = context.evaluate(name)
+          raise Liquid::SyntaxError.new("Invalid language key expression: #{exp}") if key.nil?
+
+          # get language name string from evaluated key
+          oldLanguage = context.registers[:page]['language']
+          context.registers[:page]['language'] = key
+          translation = Jekyll::LanguagePlugin::LiquidContext.get_language_string(context, "lang.#{key}")
+          context.registers[:page]['language'] = oldLanguage
+          translation
+        end
+      end
+    end
+  end
+end
+
+Liquid::Template.register_tag('tln', Jekyll::LanguagePlugin::Tags::NativeLanguageNameTag)


### PR DESCRIPTION
Added a tln tag that translates a language into its native name, not to
the current language’s name. That allows a german visitor of an english
page to see a language named „Deutsch“ instead of „German“, which makes
it easier to pick the right language.