### PR TITLE
Issue25: Fix hreflang headers in the example

### DIFF
--- a/example/_layouts/skeleton.html
+++ b/example/_layouts/skeleton.html
@@ -7,9 +7,7 @@
     <title>{% if page.title %}{{ page.title }}{% else %}{% t 'title' %}{% endif %} | {% t 'site.title' %}</title>
     <link rel="canonical" href="{{ site.url }}{{ site.baseurl }}{{ page.url }}">
     {% for language in page.languages %}
-      {% if page.language != language %}
-        <link rel="alternate" hreflang="{{ language }}" href="{{ site.url }}{{ site.baseurl }}{{ page.url | replace_first: page.language, language }}" />
-      {% endif %}
+      <link rel="alternate" hreflang="{{ language }}" href="{{ site.url }}{{ site.baseurl }}{{ page.url | replace_first: page.language, language }}" />
     {% endfor %}
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
     <script src="{{ site.baseurl }}/js/language-redirect.js" type="text/javascript"></script>


### PR DESCRIPTION
The example website's hreflang headers were ignored by Google and would not pass an hreflang test (e.g. https://technicalseo.com/seo-tools/hreflang/ ). This is simply because self-referencing headers are required but the sample had deliberately excluded them